### PR TITLE
Revert go mod version to 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mdlayher/socket
 
-go 1.21
+go 1.20
 
 require (
 	github.com/google/go-cmp v0.5.9


### PR DESCRIPTION
This avoids new 1.21 go mod management behavior which automatically upgrades a module's go mod version based on dependencies.

See #13  for discussion