### PR TITLE
netns: fix error passing from callback

### DIFF
--- a/netns_linux.go
+++ b/netns_linux.go
@@ -65,7 +65,7 @@ func withNetNS(fd int, fn func() (*Conn, error)) (*Conn, error) {
 		// No more thread-local state manipulation; return the new Conn.
 		runtime.UnlockOSThread()
 		conn = c
-		return nil
+		return err
 	})
 
 	if err := eg.Wait(); err != nil {


### PR DESCRIPTION
When callback return error, it is not forwarded.
This is preventing crash when `conn=c` is assigning null, but `err` is not returned at all.
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x47a21e]
```